### PR TITLE
Fix command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ npm i -g convert-snippets
 ## Usage
 
 ```
-convert-snippet source_file target_file
+convert-snippets source_file target_file
 ```
 
 Automatically detects `source_file` format and generates `target_file`


### PR DESCRIPTION
I believe there is a typo in the README. The command `convert-snippet` returns the error `convert-snippet: command not found`. It's just missing an `s`.