### PR TITLE
make vscode snippet body an array of strings

### DIFF
--- a/src/__tests__/generate.test.js
+++ b/src/__tests__/generate.test.js
@@ -20,7 +20,7 @@ test('Should parse Ultisnips and generate vscode snippet file', () => {
     expect(snippet).toEqual(
       expect.objectContaining({
         prefix: expect.any(String),
-        body: expect.any(String),
+        body: expect.any(Array),
       })
     )
   )
@@ -59,7 +59,7 @@ test('Should be unchanged when we json -> ultisnips and ultisnips -> json', () =
     expect(snippet).toEqual(
       expect.objectContaining({
         prefix: expect.any(String),
-        body: expect.any(String),
+        body: expect.any(Array),
       })
     )
   )

--- a/src/__tests__/parse.test.js
+++ b/src/__tests__/parse.test.js
@@ -11,10 +11,14 @@ test('Format special placeholder', () => {
 
   // then
   expect(snippets).toEqual({
-    fun: {
-      prefix: 'fun',
-      body: 'function ${1:name}(${2:params}) {\n\t$0\n}',
-    },
+    "fun": {
+      "prefix": "fun",
+      "body": [
+        "function ${1:name}(${2:params}) {",
+        "\t$0",
+        "}"
+      ]
+    }
   })
 })
 
@@ -27,15 +31,23 @@ test('Format multiple snippets', () => {
 
   // then
   expect(snippets).toEqual({
-    fun: {
-      prefix: 'fun',
-      body: 'function ${1:name}(${2:params}) {\n\t$0\n}',
-      description: 'function',
+    "fun": {
+      "prefix": "fun",
+      "body": [
+        "function ${1:name}(${2:params}) {",
+        "\t$0",
+        "}"
+      ],
+      "description": "function"
     },
-    'c=>': {
-      prefix: 'c=>',
-      body: 'const ${1:name} = (${2:params}) => {\n\t$0\n}',
-      description: 'arrow function',
+    "c=>": {
+      "prefix": "c=>",
+      "body": [
+        "const ${1:name} = (${2:params}) => {",
+        "\t$0",
+        "}"
+      ],
+      "description": "arrow function"
     },
   })
 })
@@ -58,10 +70,12 @@ test('Parse snippets with a multi-word prefix', () => {
   const snippets = parse(snippetStr)
   // then
   expect(snippets).toEqual({
-    'multi-word prefix': {
-      prefix: 'multi-word prefix',
-      body: 'This is cool',
-    },
+    "multi-word prefix": {
+      "prefix": "multi-word prefix",
+      "body": [
+        "This is cool"
+      ]
+    }
   })
 })
 

--- a/src/parse.js
+++ b/src/parse.js
@@ -9,7 +9,7 @@ function parse(rawSnippets) {
     const prefix = multiWordPrefix || singleWordPrefix
     snippets[prefix] = {
       prefix,
-      body: normalizePlaceholders(body),
+      body: normalizePlaceholders(body).split("\n"),
     }
     if (description) {
       snippets[prefix].description = description


### PR DESCRIPTION
JSON snippet body now is an array of string instead of just a monolithic string. This makes the snippet much more readable. I also modified the tests to adhere to changes.

Below are the comparison of previous and current JSON snippet: 
 
![Screenshot_20221220_120420](https://user-images.githubusercontent.com/67159758/208599519-48803a88-3f0d-4979-9ae3-007d5170dab8.png)

![Screenshot_20221220_120455](https://user-images.githubusercontent.com/67159758/208599590-7e094a9d-cf5f-4aa5-ad3f-f90db2a56557.png)
